### PR TITLE
chore: add basic Linux build and test CI workflow

### DIFF
--- a/.github/workflows/refpersys-ci.yml
+++ b/.github/workflows/refpersys-ci.yml
@@ -1,0 +1,100 @@
+name: RefPerSys CI (Linux)
+
+on:
+  push:
+    branches:
+      - master
+      - "chore/**"
+      - "feat/**"
+  pull_request:
+    branches:
+      - master
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  build-linux:
+    name: Build & Test (Ubuntu Linux)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+
+          REQUIRED_PACKAGES="make pkg-config libunistring-dev libjsoncpp-dev libssl-dev libgmp-dev libreadline-dev libncurses-dev libinih-dev libssh2-1-dev binutils-dev libiberty-dev gpp bison at"
+          FAILED_PACKAGES=""
+          for pkg in $REQUIRED_PACKAGES; do
+            echo "=== Installing $pkg ==="
+            if ! sudo apt-get install -y "$pkg"; then
+              echo "!!! ERROR: Failed to install $pkg !!!"
+              FAILED_PACKAGES="$FAILED_PACKAGES $pkg"
+            fi
+          done
+
+          if [ -n "$FAILED_PACKAGES" ]; then
+            echo "List of failed packages: $FAILED_PACKAGES"
+            exit 1
+          fi
+
+          echo "=== Installing libgccjit ==="
+          if sudo apt-get install -y libgccjit-14-dev; then
+            echo "Installed libgccjit-14-dev"
+            echo "GCC_VERSION=14" >> "$GITHUB_ENV"
+          elif sudo apt-get install -y libgccjit-13-dev; then
+            echo "Installed libgccjit-13-dev"
+            echo "GCC_VERSION=13" >> "$GITHUB_ENV"
+          else
+            echo "!!! ERROR: Failed to install libgccjit-14-dev or libgccjit-13-dev !!!"
+            exit 1
+          fi
+
+      - name: Build GNU lightning 2.2.3
+        run: |
+          set -euo pipefail
+          wget https://ftp.gnu.org/gnu/lightning/lightning-2.2.3.tar.gz
+          tar -xzf lightning-2.2.3.tar.gz
+          cd lightning-2.2.3
+          ./configure --with-gnu-ld --enable-disassembler \
+              --enable-devel-disassembler --enable-devel-get-jit-size \
+              --disable-silent-rules 'CFLAGS=-O2 -g2'
+          make -j$(nproc)
+          sudo make install
+          sudo ldconfig
+
+      - name: Build Carburetta
+        run: |
+          set -euo pipefail
+          git clone https://github.com/kingletbv/carburetta.git
+          cd carburetta
+          make
+          sudo make install
+
+      - name: Configure RefPerSys
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/tmp"
+          export CC=$(which gcc-"$GCC_VERSION")
+          export CXX=$(which g++-"$GCC_VERSION")
+          export CXXFLAGS="-O1 -g -fPIC"
+          export RPS_BUILDER_PERSON="GitHub Actions"
+          export RPS_BUILDER_EMAIL="actions@github.com"
+          export REFPERSYS_TOPDIR="$GITHUB_WORKSPACE"
+          make config
+
+      - name: Build RefPerSys
+        run: |
+          set -euo pipefail
+          export REFPERSYS_TOPDIR="$GITHUB_WORKSPACE"
+          make -j$(nproc) refpersys
+
+      - name: Run test00
+        run: |
+          set -euo pipefail
+          export REFPERSYS_TOPDIR="$GITHUB_WORKSPACE"
+          make test00

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -681,7 +681,7 @@ load_rps.o: load_rps.cc refpersys.hh \
 	        $(shell pkg-config --cflags $(PKGLIST_refpersys)) \
                 $(shell pkg-config --cflags $(PKGLIST_$(basename $(<F)))) \
                -DRPS_THIS_SOURCE=\"$<\" -DRPS_GITID=\"$(RPS_GIT_ID)\"  \
-               -DRPS_SHORTGITID=\"$(RPS_SHORTGIT_ID)\" \ \
+               -DRPS_SHORTGITID=\"$(RPS_SHORTGIT_ID)\" \
                -DRPS_HOST=\"$(RPS_HOST)\" \
 	       -DRPS_BASENAME=\"$(notdir $(basename $(<F)))\" \
 	    -DRPS_BASEID=\"$(subst -,_,$(notdir $(basename $(<F))))\" \


### PR DESCRIPTION
## Summary

This Pull Request introduces a GitHub Actions workflow to automatically build and run tests for RefPerSys on Linux (Ubuntu 24.04). It also addresses a syntax typo in the GNUmakefile that broke compilation.

## Why

I develop on macOS, so I added this Linux CI to ensure my future C++ patches won't accidentally break the upstream Linux build.

## Proposed Changes

1. **New CI Workflow** (`.github/workflows/refpersys-ci.yml`):

   - Triggers on pushes and PRs to `master`, as well as active `chore/**` or `feat/**` branches.
   - Installs all apt package dependencies, including `gpp`, `bison`, and `at` (which is required by a runtime check in `main_rps.cc`).
   - Builds and installs `GNU lightning 2.2.3` from source with JIT and disassembler flags.
   - Builds and installs the `carburetta` parser generator from source sequentially to avoid a build race condition.
   - Bootstraps the local build config (ensures `$HOME/tmp` exists for `rps-generate-buildinfo.sh`).
   - Compiles the project (`make -j$(nproc) refpersys`) and runs the primary tests (`make test00`).
 
2. **Makefile Syntax Fix** (`GNUmakefile`):
   - Corrected a syntax typo on line 682 (`\ \` changed to `\`) that broke compile rule generation for `load_rps.o`.

## Verification & Testing
- Fully tested on GitHub Actions in `TheCloudlet/RefPerSys`.
- Run output shows clean installation, compilation, and successful test completion.
- Example Green Run: [RefPerSys CI (Linux) Run #26257937280](https://github.com/TheCloudlet/RefPerSys/actions/runs/26257937280)