### PR TITLE
Add build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,236 @@
+ARG BASE_IMAGE=debian:sid-slim
+FROM ${BASE_IMAGE}
+
+ARG GCC_VERSION=15
+ARG CLANG_VERSION=19
+ARG LIGHTNING_VERSION=2.2.3
+ARG LIBBACKTRACE_REF=master
+ARG CARBURETTA_REF=master
+ARG INSTALL_OPTIONAL_FONTS=1
+ARG INSTALL_GUI_DEPS=0
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV GCC_VERSION=${GCC_VERSION}
+ENV CLANG_VERSION=${CLANG_VERSION}
+ENV CC=/usr/bin/gcc-${GCC_VERSION}
+ENV CXX=/usr/bin/g++-${GCC_VERSION}
+ENV CARBURETTA=/usr/local/bin/carburetta
+ENV MAKE=/usr/local/bin/gmake
+ENV RPS_LIBBACKTRACE=1
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+ENV LC_TIME=en_US.UTF-8
+ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/share/pkgconfig
+ENV LD_LIBRARY_PATH=/usr/local/lib
+ENV PATH=/usr/lib/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get dist-upgrade -y; \
+    apt-get install -y --no-install-recommends \
+      apt-utils \
+      astyle \
+      at \
+      automake \
+      autoconf \
+      bash \
+      bcpp \
+      binutils-dev \
+      bison \
+      bisonc++ \
+      bisonc++-doc \
+      bsd-mailx \
+      ca-certificates \
+      ccache \
+      clang-${CLANG_VERSION} \
+      clang-tidy-${CLANG_VERSION} \
+      cmake \
+      curl \
+      dpkg-dev \
+      file \
+      flex \
+      g++-${GCC_VERSION} \
+      gcc-${GCC_VERSION} \
+      gdb \
+      git \
+      gpp \
+      guile-3.0-dev \
+      hostname \
+      less \
+      locales \
+      libbz2-dev \
+      libcurl4-openssl-dev \
+      libcurlpp-dev \
+      libgccjit-${GCC_VERSION}-dev \
+      libgmp-dev \
+      libc6-dev \
+      libinih-dev \
+      libjsoncpp-dev \
+      libncurses-dev \
+      libreadline-dev \
+      libssl-dev \
+      libtool \
+      libunistring-dev \
+      libzstd-dev \
+      make-guile \
+      msmtp-mta \
+      ninja-build \
+      pkg-config \
+      plocate \
+      procps \
+      qt6-base-dev-tools \
+      remake \
+      tar \
+      texinfo \
+      uncrustify \
+      xz-utils \
+      zlib1g-dev; \
+    ln -sf /usr/bin/make /usr/local/bin/gmake; \
+    ln -sf /usr/bin/clang-tidy-${CLANG_VERSION} /usr/local/bin/clang-tidy; \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VERSION} 150; \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${GCC_VERSION} 150; \
+    update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-${GCC_VERSION} 150; \
+    update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-${GCC_VERSION} 150; \
+    sed -i 's/^# *\(en_US.UTF-8 UTF-8\)/\1/' /etc/locale.gen; \
+    locale-gen en_US.UTF-8; \
+    printf '/usr/local/lib\n' > /etc/ld.so.conf.d/usr-local-lib.conf; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    if [[ "${INSTALL_OPTIONAL_FONTS}" == "1" ]]; then \
+      apt-get update; \
+      optional_fonts=( \
+        fonts-cegui \
+        fonts-croscore \
+        fonts-dejavu \
+        fonts-ecolier-court \
+        fonts-eurofurence \
+        fonts-inconsolata \
+        fonts-inter \
+        fonts-play \
+        fonts-recommended \
+        fonts-roboto \
+        fonts-spleen \
+        fonts-tuffy \
+        fonts-ubuntu \
+        fonts-unifont \
+        fonts-yanone-kaffeesatz \
+        msttcorefonts \
+        ttf-mscorefonts-installer \
+        ttf-unifont \
+        unifont \
+      ); \
+      install_fonts=(); \
+      for package in "${optional_fonts[@]}"; do \
+        candidate="$(apt-cache policy "${package}" | sed -n 's/^  Candidate: //p' | head -n 1)"; \
+        if [[ -n "${candidate}" && "${candidate}" != "(none)" ]]; then \
+          install_fonts+=("${package}"); \
+        fi; \
+      done; \
+      if (( ${#install_fonts[@]} )); then \
+        apt-get install -y --no-install-recommends "${install_fonts[@]}"; \
+      fi; \
+      rm -rf /var/lib/apt/lists/*; \
+    fi
+
+RUN set -eux; \
+    if [[ "${INSTALL_GUI_DEPS}" == "1" ]]; then \
+      apt-get update; \
+      optional_gui_deps=( \
+        libfox-1.6-dev \
+        libglibmm-2.68-dev \
+        libgtkmm-3.0-dev \
+        libgtkmm-4.0-dev \
+        libonion-dev \
+        qt6-base-dev \
+      ); \
+      install_gui_deps=(); \
+      for package in "${optional_gui_deps[@]}"; do \
+        if apt-cache show "${package}" >/dev/null 2>&1; then \
+          install_gui_deps+=("${package}"); \
+        fi; \
+      done; \
+      if (( ${#install_gui_deps[@]} )); then \
+        apt-get install -y --no-install-recommends "${install_gui_deps[@]}"; \
+      fi; \
+      rm -rf /var/lib/apt/lists/*; \
+    fi
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends libiberty-dev; \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp/refpersys-deps
+
+RUN set -eux; \
+    curl -fsSL "https://ftp.gnu.org/gnu/lightning/lightning-${LIGHTNING_VERSION}.tar.gz" -o lightning.tar.gz; \
+    tar -xzf lightning.tar.gz; \
+    cd "lightning-${LIGHTNING_VERSION}"; \
+    ./configure \
+      --with-gnu-ld \
+      --enable-disassembler \
+      --enable-devel-disassembler \
+      --enable-devel-get-jit-size \
+      --disable-silent-rules \
+      CFLAGS='-O2 -g2'; \
+    gmake -j"$(nproc)"; \
+    gmake install; \
+    ldconfig
+
+RUN set -eux; \
+    git clone --depth 1 https://github.com/ianlancetaylor/libbacktrace.git /tmp/refpersys-deps/libbacktrace; \
+    cd /tmp/refpersys-deps/libbacktrace; \
+    if [[ "${LIBBACKTRACE_REF}" != "master" ]]; then \
+      git fetch --depth 1 origin "${LIBBACKTRACE_REF}"; \
+      git checkout --detach FETCH_HEAD; \
+    fi; \
+    ./configure --prefix=/usr/local --enable-shared; \
+    gmake -j"$(nproc)"; \
+    gmake install; \
+    ldconfig
+
+RUN set -eux; \
+    git clone --depth 1 https://github.com/kingletbv/carburetta.git /tmp/refpersys-deps/carburetta; \
+    cd /tmp/refpersys-deps/carburetta; \
+    if [[ "${CARBURETTA_REF}" != "master" ]]; then \
+      git fetch --depth 1 origin "${CARBURETTA_REF}"; \
+      git checkout --detach FETCH_HEAD; \
+    fi; \
+    gmake -j"$(nproc)" build/carburetta; \
+    install -m 0755 build/carburetta /usr/local/bin/carburetta; \
+    carburetta --help >/tmp/carburetta-help.txt; \
+    grep -qi carburetta /tmp/carburetta-help.txt
+
+RUN set -eux; \
+    ldconfig; \
+    updatedb; \
+    test -x /usr/local/bin/gmake; \
+    test -x /usr/local/bin/carburetta; \
+    test -x /bin/at; \
+    test -x /usr/lib/qt6/libexec/moc; \
+    command -v getent; \
+    command -v setpriv; \
+    test -r /usr/local/include/lightning.h; \
+    test -r /usr/local/include/backtrace.h; \
+    test -r "$(${CC} -print-file-name=include)/libgccjit.h"; \
+    command -v mail; \
+    pkg-config --exists curlpp; \
+    pkg-config --exists gmp; \
+    pkg-config --exists gmpxx; \
+    pkg-config --exists guile-3.0; \
+    pkg-config --exists INIReader; \
+    pkg-config --exists inih; \
+    pkg-config --exists jsoncpp; \
+    pkg-config --exists readline; \
+    locale -a | grep -Ei '^en_US\.utf-?8$'; \
+    locate libopcodes.so | grep -q .; \
+    rm -rf /tmp/refpersys-deps
+
+COPY docker/refpersys-build-entrypoint.sh /usr/local/bin/refpersys-build-entrypoint
+RUN chmod +x /usr/local/bin/refpersys-build-entrypoint
+
+WORKDIR /workspace/RefPerSys
+ENTRYPOINT ["refpersys-build-entrypoint"]

--- a/RUN_TESTS
+++ b/RUN_TESTS
@@ -1,0 +1,42 @@
+#!/usr/bin/env sh
+set -eu
+
+image="${REFPERSYS_DOCKER_IMAGE:-refpersys-build:latest}"
+engine="${CONTAINER_ENGINE:-}"
+platform="${REFPERSYS_DOCKER_PLATFORM:-linux/amd64}"
+
+if [ -z "$engine" ]; then
+  if command -v docker >/dev/null 2>&1; then
+    engine=docker
+  elif command -v podman >/dev/null 2>&1; then
+    engine=podman
+  else
+    echo "RUN_TESTS: docker or podman is required" >&2
+    exit 127
+  fi
+fi
+
+repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+build_args="${REFPERSYS_DOCKER_BUILD_ARGS:-}"
+host_uid=$(id -u)
+host_gid=$(id -g)
+
+# Intentionally split REFPERSYS_DOCKER_BUILD_ARGS so callers can pass
+# ordinary docker build flags, for example:
+#   REFPERSYS_DOCKER_BUILD_ARGS='--build-arg INSTALL_GUI_DEPS=1'
+"$engine" build --platform "$platform" $build_args -t "$image" "$repo_dir"
+
+tty_flags="-i"
+if [ -t 0 ]; then
+  tty_flags="-it"
+fi
+
+exec "$engine" run --rm $tty_flags \
+  --platform "$platform" \
+  --env HOME=/tmp/refpersys-home \
+  --env REFPERSYS_TOPDIR=/workspace/RefPerSys \
+  --env REFPERSYS_HOST_UID="$host_uid" \
+  --env REFPERSYS_HOST_GID="$host_gid" \
+  --volume "$repo_dir:/workspace/RefPerSys" \
+  --workdir /workspace/RefPerSys \
+  "$image" "$@"

--- a/docker/refpersys-build-entrypoint.sh
+++ b/docker/refpersys-build-entrypoint.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export HOME="${HOME:-/tmp/refpersys-home}"
+export REFPERSYS_TOPDIR="${REFPERSYS_TOPDIR:-$PWD}"
+export CC="${CC:-/usr/bin/gcc-${GCC_VERSION:-15}}"
+export CXX="${CXX:-/usr/bin/g++-${GCC_VERSION:-15}}"
+export CXXFLAGS="${CXXFLAGS:--O2 -g -fPIC}"
+export CARBURETTA="${CARBURETTA:-/usr/local/bin/carburetta}"
+export RPS_BUILDER_PERSON="${RPS_BUILDER_PERSON:-RefPerSys Docker Builder}"
+export RPS_BUILDER_EMAIL="${RPS_BUILDER_EMAIL:-refpersys-docker@example.invalid}"
+export RPS_LIBBACKTRACE="${RPS_LIBBACKTRACE:-1}"
+export PATH="/usr/lib/ccache:/usr/local/bin:$PATH"
+
+mkdir -p "$HOME" "$HOME/tmp"
+
+if [[ "$(id -u)" -eq 0 && -n "${REFPERSYS_HOST_UID:-}" && "${REFPERSYS_HOST_UID}" != "0" ]]; then
+  target_uid="${REFPERSYS_HOST_UID}"
+  target_gid="${REFPERSYS_HOST_GID:-$target_uid}"
+  target_user="$(getent passwd "$target_uid" | cut -d: -f1 || true)"
+
+  if [[ -z "$target_user" ]]; then
+    target_user="refpersys"
+    if getent passwd "$target_user" >/dev/null; then
+      target_user="refpersys${target_uid}"
+    fi
+    if ! getent group "$target_gid" >/dev/null; then
+      printf '%s:x:%s:\n' "$target_user" "$target_gid" >> /etc/group
+    fi
+    printf '%s:x:%s:%s::%s:/bin/bash\n' \
+      "$target_user" "$target_uid" "$target_gid" "$HOME" >> /etc/passwd
+  fi
+
+  chown "$target_uid:$target_gid" "$HOME" "$HOME/tmp"
+  exec setpriv --reuid "$target_uid" --regid "$target_gid" --clear-groups "$0" "$@"
+fi
+
+if [[ $# -eq 0 ]]; then
+  set -- bash -lc 'gmake config && gmake -j"$(nproc)" all && gmake test00'
+fi
+
+exec "$@"


### PR DESCRIPTION
The purpose of this pull request is to make it easier to run the tests in one step from a portable docker container. I can stand in the native terminal and run a script

`$ ./RUN_TESTS`

then the script RUN_TESTS will start a docker container which is portable, so a new system would not need to install dependencies, and we have a portable test environment with the docker container. 

**Usage**

```
% ./RUN_TESTS 
[+] Building 1.0s (18/18) FINISHED                                                                                                          docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                        0.0s
 => => transferring dockerfile: 7.12kB                                                                                                                      0.0s
....

RefPerSys process 2193 on host 6541d846cbbe in /workspace/RefPerSys
… git d70bf9919af5 version 0.7 exiting β (0);
… elapsed 2.236 sec, CPU 0.649 sec
… run: test00.5



////test00 FINISHED¤
```